### PR TITLE
Fix docker build fail due to dependency changes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN apt update && \
     ros-$ROS_VERSION-xacro \
     ros-$ROS_VERSION-rviz2 \
     ros-$ROS_VERSION-actuator-msgs \
+    ros-$ROS_VERSION-vision-msgs \
     python3-pip && \
     pip install setuptools==58.2.0
 
@@ -44,7 +45,7 @@ WORKDIR /home/leo
 RUN mkdir -p /home/leo/ros2_ws/src/
 WORKDIR /home/leo/ros2_ws/src/
 RUN git clone -b $ROS_VERSION --single-branch https://github.com/gazebosim/ros_gz.git
-RUN git clone -b ros2 --single-branch https://github.com/ros/sdformat_urdf.git
+RUN git clone -b humble --single-branch https://github.com/ros/sdformat_urdf.git
 WORKDIR /home/leo/ros2_ws/
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash; colcon build --symlink-install --executor sequential"
 


### PR DESCRIPTION
This fixes the docker build problems I ran into and submitted as issues #5 and #6. 

The build completes and launches gz and rviz2. I have not tested this against leorover control nodes.

I have some follow up questions:
1. I noticed you had some attempt to install garden from binaries, but ended up installing from source. I'd love to hear if this is an expediency due to roadblocks or just a choice you made to be able to experiment with garden.
2.  There are a lot of traces of ignition (fortress) remaining. Is that related to the prior question or just not a priority to clean out?

Thank you for contributing this project!